### PR TITLE
Add git pull to entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,8 +11,9 @@ setOutput() {
     echo "${1}=${2}" >> "${GITHUB_OUTPUT}"
 }
 
-# this fetch _should_ be redundant - but is useful for debugging if nothing else
-git fetch --tags
+# this fetch is useful for debugging too
+git fetch
+git checkout origin/main
 
 tagFmt="^v?[0-9]+\.[0-9]+\.[0-9]+$"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,9 +11,13 @@ setOutput() {
     echo "${1}=${2}" >> "${GITHUB_OUTPUT}"
 }
 
-# this fetch is useful for debugging too
-git fetch
-git checkout origin/main
+# this fetch is useful for debugging
+git fetch --tags
+
+# Make sure you have the latest changes on the branch.
+# Needed for the make-release job which pushes a new commit before this.
+# A bit hacky - we'd rather pass in a optional commit hash to tag.
+git pull
 
 tagFmt="^v?[0-9]+\.[0-9]+\.[0-9]+$"
 


### PR DESCRIPTION
Because the checkout action checks out the commit from which it is being run, which isn't quite what we want when we've just pushed an empty commit for version-bumping.